### PR TITLE
chore: drop @types in favor of newer localforage & sqlitedriver versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,8 @@
   },
   "homepage": "https://github.com/driftyco/ionic-storage#readme",
   "dependencies": {
-    "@types/localforage": "0.0.30",
-    "localforage": "~1.4.2",
-    "localforage-cordovasqlitedriver": "~1.5.0"
+    "localforage": "^1.5.0",
+    "localforage-cordovasqlitedriver": "^1.6.0"
   },
   "devDependencies": {
     "@angular/core": "2.2.1",


### PR DESCRIPTION
As noted in #28, this weekend we released localForage v1.5.0 which includes it's own typings (+ localforage-cordovasqlitedriver v1.6.0). As a result there is no longer a need to reference the respective @types package.