### PR TITLE
feature(indexDB): Support indexDB for Safari browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/driftyco/ionic-storage#readme",
   "dependencies": {
-    "@types/localforage": "0.0.30",
+    "@types/localforage": "0.0.34",
     "localforage": "~1.5.0",
     "localforage-cordovasqlitedriver": "~1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "homepage": "https://github.com/driftyco/ionic-storage#readme",
   "dependencies": {
     "@types/localforage": "0.0.30",
-    "localforage": "~1.4.2",
-    "localforage-cordovasqlitedriver": "~1.5.0"
+    "localforage": "~1.5.0",
+    "localforage-cordovasqlitedriver": "~1.6.0"
   },
   "devDependencies": {
     "@angular/core": "2.4.8",


### PR DESCRIPTION
localForage 1.5.0 supports now indexDB for Safari browser: "We now use IndexedDB as the storage engine for Safari v10.1 (and above)."

localforage-cordovasqlitedriver updated also to localForage 1.5.0: https://github.com/thgreasi/localForage-cordovaSQLiteDriver/pull/19