### PR TITLE
Update LocalForage dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,11 +42,6 @@
         "tsickle": "0.21.6"
       }
     },
-    "@types/localforage": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/localforage/-/localforage-0.0.30.tgz",
-      "integrity": "sha1-PWCmv23aOOP4pGlhFZg3nx9klQk="
-    },
     "@types/node": {
       "version": "6.0.90",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz",
@@ -2374,20 +2369,19 @@
       }
     },
     "localforage": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.4.3.tgz",
-      "integrity": "sha1-ohJUPDnHx2Qk7dEr9HTEiarKSUw=",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.5.5.tgz",
+      "integrity": "sha1-VfwcOoikf2f1+sbxIxsl/xNVZCM=",
       "requires": {
         "lie": "3.0.2"
       }
     },
     "localforage-cordovasqlitedriver": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/localforage-cordovasqlitedriver/-/localforage-cordovasqlitedriver-1.5.0.tgz",
-      "integrity": "sha1-+TR4nmrZo5usBf3RFogS9DhTV2I=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/localforage-cordovasqlitedriver/-/localforage-cordovasqlitedriver-1.6.0.tgz",
+      "integrity": "sha1-kCcMqpXusQoDl4Mf4QYRiIUwfXE=",
       "requires": {
-        "@types/localforage": "0.0.30",
-        "localforage": "1.4.3"
+        "localforage": "1.5.5"
       }
     },
     "lodash": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,8 @@
   },
   "homepage": "https://github.com/ionic-team/ionic-storage#readme",
   "dependencies": {
-    "@types/localforage": "0.0.30",
-    "localforage": "~1.4.2",
-    "localforage-cordovasqlitedriver": "~1.5.0"
+    "localforage": "~1.5.5",
+    "localforage-cordovasqlitedriver": "~1.6.0"
   },
   "devDependencies": {
     "@angular/compiler": "4.4.4",


### PR DESCRIPTION
This solves #133 by giving developers the ability to monkey patch the instance. Once this PR is approved the following code would allow IndexedDB to work on Safari 10.1+ when using Ionic.

```
import { Storage } from "@ionic/storage";

constructor( private storage: Storage ) {
        this.storage.ready().then( ( localForageInstance ) => {
            localForageInstance.getDriver( localForageInstance.INDEXEDDB ).then( ( driver ) => {
                if ( driver._support ) {
                    this.init();
                } else {
                    driver._support = true;
                    return localForageInstance.defineDriver( driver ).then( () => {
                        localForageInstance.setDriver( localForageInstance.INDEXEDDB ).then( this.init.bind( this ) );
                    } );
                }
            } );
}

private init() { console.log( "Loaded!" ); }
```