### PR TITLE
adding support for Cordova-sqlcipher-adapter via thgreasi/localForage-cordovaSQLiteDriver

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -225,6 +225,7 @@ export function getDefaultConfig() {
   return {
     name: '_ionicstorage',
     storeName: '_ionickv',
+    dbKey: '_ionickey',
     driverOrder: ['sqlite', 'indexeddb', 'websql', 'localstorage']
   };
 }
@@ -233,6 +234,7 @@ export function getDefaultConfig() {
 export interface StorageConfig {
   name?: string;
   storeName?: string;
+  dbKey?: string;
   driverOrder?: string[];
 };
 


### PR DESCRIPTION
adding dbKey will enable usage of cordova-sqlcipher-adapter 