### PR TITLE
Fix default config override.

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -49,7 +49,7 @@ export class Storage {
    * Secure Storage is used when available, or fall back to IndexedDB or LocalStorage on the web.
    */
   constructor(config: StorageConfig = defaultConfig) {
-    const actualConfig = Object.assign(defaultConfig, config || {});
+    const actualConfig = Object.assign({}, defaultConfig, config || {});
     this._config = actualConfig;
   }
 


### PR DESCRIPTION
In my project I was using several storeName and found this bug. 

Basically any custom configuration was overriding the default settings instead of cloning them .