### PR TITLE
Fix syntax for the cordova sqlite driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ npm install localforage-cordovasqlitedriver
 For non-Angular projects, pass the `CordovaSQLiteDriver._driver` to the `driverOrder` config option:
 
 ```typescript
-import * as CordovaSQLiteDriver from 'localforage-cordovasqlitedriver';
+import CordovaSQLiteDriver from 'localforage-cordovasqlitedriver';
 
 const store = new Storage({
   driverOrder: [CordovaSQLiteDriver._driver, Drivers.IndexedDB, Drivers.LocalStorage]
@@ -257,7 +257,11 @@ export class MyPageModule { }
 Finally, to register the driver, run `defineDriver()` on the storage instance to register the driver, making sure to call this before any data operations:
 
 ```typescript
-import * as CordovaSQLiteDriver from 'localforage-cordovasqlitedriver'
+import CordovaSQLiteDriver from 'localforage-cordovasqlitedriver'
+
+const store = new Storage({
+  driverOrder: [CordovaSQLiteDriver._driver, Drivers.IndexedDB, Drivers.LocalStorage]
+});
 
 await this.storage.defineDriver(CordovaSQLiteDriver);
 ```

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ const store = new Storage({
 In Angular, pass the same configuration when importing the `IonicStorageModule` in your page or app `NgModule`:
 
 ```typescript
-import * as CordovaSQLiteDriver from 'localforage-cordovasqlitedriver';
+import CordovaSQLiteDriver from 'localforage-cordovasqlitedriver';
 
 @NgModule({
   imports: [


### PR DESCRIPTION
The syntax for the SQLite portion of the guide has become outdated and now is non-functional. These simple changes fix everything broken by this change.