### PR TITLE
Fix #247 - Remove unusable source maps

### DIFF
--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -12,7 +12,6 @@
     "noUnusedParameters": true,
     "outDir": "dist/esm",
     "pretty": true,
-    "sourceMap": true,
     "strict": true,
     "target": "es2017"
   },


### PR DESCRIPTION
Since the release files in npm do not include the Typescript sources, a sourcemap-file is useless. Webpack will show warnings because of the missing source files, because the source maps files exist, but point to non-existing sources.

This change fixes #247.